### PR TITLE
Add Redis caching for order management

### DIFF
--- a/src/OrderPlacer.AppHost/AppHost.cs
+++ b/src/OrderPlacer.AppHost/AppHost.cs
@@ -2,6 +2,7 @@ var builder = DistributedApplication.CreateBuilder(args);
 
 // Infrastructure
 var rabbitmq = builder.AddRabbitMQ("rabbitmq");
+var redis = builder.AddRedis("redis");
 var postgres = builder.AddPostgres("postgres")
     .WithDataVolume()
     .AddDatabase("order-placer");
@@ -11,7 +12,9 @@ var ordersApi = builder.AddProject<Projects.OrderPlacer_Orders_Api>("orders-api"
     .WithReference(postgres)
     .WaitFor(postgres)
     .WithReference(rabbitmq)
-    .WaitFor(rabbitmq);
+    .WaitFor(rabbitmq)
+    .WithReference(redis)
+    .WaitFor(redis);
 
 var fulfillmentService = builder.AddProject<Projects.OrderPlacer_Fulfillment_Service>("fulfillment-service")
     .WithReference(rabbitmq)

--- a/src/OrderPlacer.AppHost/OrderPlacer.AppHost.csproj
+++ b/src/OrderPlacer.AppHost/OrderPlacer.AppHost.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <Sdk Name="Aspire.AppHost.Sdk" Version="9.4.0"/>
+    <Sdk Name="Aspire.AppHost.Sdk" Version="9.4.0" />
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -11,15 +11,16 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspire.Hosting.AppHost" Version="9.4.0"/>
+        <PackageReference Include="Aspire.Hosting.AppHost" Version="9.4.0" />
         <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="9.4.0" />
         <PackageReference Include="Aspire.Hosting.RabbitMQ" Version="9.4.0" />
+        <PackageReference Include="Aspire.Hosting.Redis" Version="9.4.0" />
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\OrderPlacer.Fulfillment.Service\OrderPlacer.Fulfillment.Service.csproj" />
-      <ProjectReference Include="..\OrderPlacer.Gateway\OrderPlacer.Gateway.csproj" />
-      <ProjectReference Include="..\OrderPlacer.Orders.Api\OrderPlacer.Orders.Api.csproj" />
+        <ProjectReference Include="..\OrderPlacer.Fulfillment.Service\OrderPlacer.Fulfillment.Service.csproj" />
+        <ProjectReference Include="..\OrderPlacer.Gateway\OrderPlacer.Gateway.csproj" />
+        <ProjectReference Include="..\OrderPlacer.Orders.Api\OrderPlacer.Orders.Api.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/OrderPlacer.Orders.Api/Consumers/OrderStatusUpdatedConsumer.cs
+++ b/src/OrderPlacer.Orders.Api/Consumers/OrderStatusUpdatedConsumer.cs
@@ -2,10 +2,11 @@ using MassTransit;
 using Microsoft.EntityFrameworkCore;
 using OrderPlacer.Contracts;
 using OrderPlacer.Orders.Api.Data;
+using OrderPlacer.Orders.Api.Services;
 
 namespace OrderPlacer.Orders.Api.Consumers;
 
-public class OrderStatusUpdatedConsumer(OrdersDbContext dbContext) : IConsumer<OrderStatusUpdated>
+public class OrderStatusUpdatedConsumer(OrdersDbContext dbContext, IOrderCacheService cacheService) : IConsumer<OrderStatusUpdated>
 {
     public async Task Consume(ConsumeContext<OrderStatusUpdated> context)
     {
@@ -22,5 +23,7 @@ public class OrderStatusUpdatedConsumer(OrdersDbContext dbContext) : IConsumer<O
 
         dbContext.Orders.Update(order);
         await dbContext.SaveChangesAsync(context.CancellationToken);
+
+        await cacheService.InvalidateOrderAsync(context.Message.OrderId, context.CancellationToken);
     }
 }

--- a/src/OrderPlacer.Orders.Api/OrderPlacer.Orders.Api.csproj
+++ b/src/OrderPlacer.Orders.Api/OrderPlacer.Orders.Api.csproj
@@ -1,24 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-    <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
-        <Nullable>enable</Nullable>
-        <ImplicitUsings>enable</ImplicitUsings>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.4.0" />
-        <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.4.0" />
-        <PackageReference Include="FastEndpoints" Version="7.0.1" />
-        <PackageReference Include="MassTransit.RabbitMQ" Version="8.5.1" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.7">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.4.0" />
+    <PackageReference Include="Aspire.StackExchange.Redis" Version="9.4.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.4.0" />
+    <PackageReference Include="FastEndpoints" Version="7.0.1" />
+    <PackageReference Include="MassTransit.RabbitMQ" Version="8.5.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.7">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\OrderPlacer.Contracts\OrderPlacer.Contracts.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\OrderPlacer.Contracts\OrderPlacer.Contracts.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/src/OrderPlacer.Orders.Api/Program.cs
+++ b/src/OrderPlacer.Orders.Api/Program.cs
@@ -2,12 +2,17 @@ using FastEndpoints;
 using MassTransit;
 using OrderPlacer.Orders.Api.Consumers;
 using OrderPlacer.Orders.Api.Data;
+using OrderPlacer.Orders.Api.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services
 builder.Services.AddFastEndpoints();
 builder.AddNpgsqlDbContext<OrdersDbContext>("order-placer");
+
+builder.Services.AddStackExchangeRedisCache(options => options.Configuration = builder.Configuration.GetConnectionString("redis"));
+
+builder.Services.AddScoped<IOrderCacheService, OrderCacheService>();
 
 builder.Services.AddMassTransit(busConfigurator =>
 {
@@ -17,8 +22,7 @@ builder.Services.AddMassTransit(busConfigurator =>
 
     busConfigurator.UsingRabbitMq((context, configurator) =>
     {
-        var connectionString = builder.Configuration.GetConnectionString("rabbitmq");
-        configurator.Host(connectionString);
+        configurator.Host(builder.Configuration.GetConnectionString("rabbitmq"));
         configurator.ConfigureEndpoints(context);
     });
 });

--- a/src/OrderPlacer.Orders.Api/Services/IOrderCacheService.cs
+++ b/src/OrderPlacer.Orders.Api/Services/IOrderCacheService.cs
@@ -1,0 +1,10 @@
+using OrderPlacer.Orders.Api.Endpoints.GetOrder;
+
+namespace OrderPlacer.Orders.Api.Services;
+
+public interface IOrderCacheService
+{
+    Task<GetOrderResponse?> GetOrderAsync(Guid orderId, CancellationToken cancellationToken = default);
+    Task SetOrderAsync(GetOrderResponse order, CancellationToken cancellationToken = default);
+    Task InvalidateOrderAsync(Guid orderId, CancellationToken cancellationToken = default);
+}

--- a/src/OrderPlacer.Orders.Api/Services/OrderCacheService.cs
+++ b/src/OrderPlacer.Orders.Api/Services/OrderCacheService.cs
@@ -1,0 +1,48 @@
+using System.Text.Json;
+using Microsoft.Extensions.Caching.Distributed;
+using OrderPlacer.Orders.Api.Endpoints.GetOrder;
+
+namespace OrderPlacer.Orders.Api.Services;
+
+public class OrderCacheService(IDistributedCache cache) : IOrderCacheService
+{
+    private static readonly TimeSpan DefaultCacheExpiration = TimeSpan.FromMinutes(5);
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    public async Task<GetOrderResponse?> GetOrderAsync(Guid orderId, CancellationToken cancellationToken = default)
+    {
+        var cacheKey = GetCacheKey(orderId);
+        var cachedOrder = await cache.GetStringAsync(cacheKey, cancellationToken);
+
+        if (string.IsNullOrEmpty(cachedOrder))
+        {
+            return null;
+        }
+
+        return JsonSerializer.Deserialize<GetOrderResponse>(cachedOrder, JsonOptions);
+    }
+
+    public async Task SetOrderAsync(GetOrderResponse order, CancellationToken cancellationToken = default)
+    {
+        var cacheKey = GetCacheKey(order.Id);
+        var serializedOrder = JsonSerializer.Serialize(order, JsonOptions);
+
+        var options = new DistributedCacheEntryOptions
+        {
+            AbsoluteExpirationRelativeToNow = DefaultCacheExpiration
+        };
+
+        await cache.SetStringAsync(cacheKey, serializedOrder, options, cancellationToken);
+    }
+
+    public async Task InvalidateOrderAsync(Guid orderId, CancellationToken cancellationToken = default)
+    {
+        var cacheKey = GetCacheKey(orderId);
+        await cache.RemoveAsync(cacheKey, cancellationToken);
+    }
+
+    private static string GetCacheKey(Guid orderId) => $"order:{orderId}";
+}


### PR DESCRIPTION
Introduce IOrderCacheService and OrderCacheService for caching order data. Update AppHost to include Redis service and modify GetOrderEndpoint and OrderStatusUpdatedConsumer to utilize caching. Update project files with necessary Redis package references.